### PR TITLE
[#23] Rename pgexporter_ext SQL functions to match C implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .cache
+.idea/

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Jesper Pedersen <jesper.pedersen@redhat.com>
 Saurav Pal <resyfer.dev@gmail.com>
 Shikhar Soni <shikharish05@gmail.com>
 Arshdeep Singh <balarsh535@gmail.com>
+Ahmed Mordi <ahmed.m.hamada2003@gmail.com>

--- a/sql/pgexporter_ext--0.1.0.sql
+++ b/sql/pgexporter_ext--0.1.0.sql
@@ -1,20 +1,20 @@
-CREATE FUNCTION pgexporter_used_space(IN dir text) RETURNS bigint
+CREATE FUNCTION pgexporter_ext_used_space(IN dir text) RETURNS bigint
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_used_space FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_used_space TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_used_space FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_used_space TO pg_monitor;
 
-CREATE FUNCTION pgexporter_free_space(IN dir text) RETURNS bigint
+CREATE FUNCTION pgexporter_ext_free_space(IN dir text) RETURNS bigint
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_free_space FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_free_space TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_free_space FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_free_space TO pg_monitor;
 
-CREATE FUNCTION pgexporter_total_space(IN dir text) RETURNS bigint
+CREATE FUNCTION pgexporter_ext_total_space(IN dir text) RETURNS bigint
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_total_space FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_total_space TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_total_space FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_total_space TO pg_monitor;

--- a/sql/pgexporter_ext--0.1.1--0.2.0.sql
+++ b/sql/pgexporter_ext--0.1.1--0.2.0.sql
@@ -1,33 +1,33 @@
-CREATE FUNCTION pgexporter_information_ext() RETURNS text
+CREATE FUNCTION pgexporter_ext_information() RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_information_ext FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_information_ext TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_information FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_information TO pg_monitor;
 
-CREATE FUNCTION pgexporter_version_ext() RETURNS text
+CREATE FUNCTION pgexporter_ext_version() RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_version_ext FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_version_ext TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_version FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_version TO pg_monitor;
 
-CREATE FUNCTION pgexporter_is_supported(IN fname text) RETURNS bool
+CREATE FUNCTION pgexporter_ext_is_supported(IN fname text) RETURNS bool
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_is_supported FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_is_supported TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_is_supported FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_is_supported TO pg_monitor;
 
-CREATE FUNCTION pgexporter_get_functions(OUT fname text, OUT has_input bool, OUT description text, OUT ftype text)
+CREATE FUNCTION pgexporter_ext_get_functions(OUT fname text, OUT has_input bool, OUT description text, OUT ftype text)
 RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_get_functions FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_get_functions TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_get_functions FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_get_functions TO pg_monitor;
 
-CREATE FUNCTION pgexporter_os_info(OUT name text,
+CREATE FUNCTION pgexporter_ext_os_info(OUT name text,
                                    OUT version text,
                                    OUT architecture text,
                                    OUT host_name text,
@@ -39,10 +39,10 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_os_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_os_info TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_os_info FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_os_info TO pg_monitor;
 
-CREATE FUNCTION pgexporter_cpu_info(OUT vendor text,
+CREATE FUNCTION pgexporter_ext_cpu_info(OUT vendor text,
                                     OUT model_name text,
                                     OUT number_of_cores int,
                                     OUT clock_speed_hz int8,
@@ -55,10 +55,10 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_cpu_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_cpu_info TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_cpu_info FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_cpu_info TO pg_monitor;
 
-CREATE FUNCTION pgexporter_memory_info(OUT total_memory int8,
+CREATE FUNCTION pgexporter_ext_memory_info(OUT total_memory int8,
                                        OUT used_memory int8,
                                        OUT free_memory int8,
                                        OUT swap_total int8,
@@ -70,10 +70,10 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_memory_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_memory_info TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_memory_info FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_memory_info TO pg_monitor;
 
-CREATE FUNCTION pgexporter_load_avg(OUT load_avg_one_minute float4,
+CREATE FUNCTION pgexporter_ext_load_avg(OUT load_avg_one_minute float4,
                                     OUT load_avg_five_minutes float4,
                                     OUT load_avg_ten_minutes float4
 )
@@ -81,10 +81,10 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_load_avg FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_load_avg TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_load_avg FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_load_avg TO pg_monitor;
 
-CREATE FUNCTION pgexporter_network_info(OUT interface_name text,
+CREATE FUNCTION pgexporter_ext_network_info(OUT interface_name text,
                                         OUT ip_address text,
                                         OUT tx_bytes int8,
                                         OUT tx_packets int8,
@@ -100,5 +100,5 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-REVOKE ALL ON FUNCTION pgexporter_network_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_network_info TO pg_monitor;
+REVOKE ALL ON FUNCTION pgexporter_ext_network_info FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pgexporter_ext_network_info TO pg_monitor;

--- a/sql/pgexporter_ext--0.2.4--0.3.0.sql
+++ b/sql/pgexporter_ext--0.2.4--0.3.0.sql
@@ -1,4 +1,3 @@
--- Create functions for each log level
 CREATE FUNCTION pgexporter_ext_log_debug5() RETURNS int
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
@@ -47,7 +46,6 @@ CREATE FUNCTION pgexporter_ext_log_panic() RETURNS int
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
--- Revoke all permissions from PUBLIC
 REVOKE ALL ON FUNCTION pgexporter_ext_log_debug5() FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgexporter_ext_log_debug4() FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgexporter_ext_log_debug3() FROM PUBLIC;
@@ -61,7 +59,6 @@ REVOKE ALL ON FUNCTION pgexporter_ext_log_log() FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgexporter_ext_log_fatal() FROM PUBLIC;
 REVOKE ALL ON FUNCTION pgexporter_ext_log_panic() FROM PUBLIC;
 
--- Grant EXECUTE permission to pg_monitor role
 GRANT EXECUTE ON FUNCTION pgexporter_ext_log_debug5() TO pg_monitor;
 GRANT EXECUTE ON FUNCTION pgexporter_ext_log_debug4() TO pg_monitor;
 GRANT EXECUTE ON FUNCTION pgexporter_ext_log_debug3() TO pg_monitor;
@@ -74,143 +71,3 @@ GRANT EXECUTE ON FUNCTION pgexporter_ext_log_error() TO pg_monitor;
 GRANT EXECUTE ON FUNCTION pgexporter_ext_log_log() TO pg_monitor;
 GRANT EXECUTE ON FUNCTION pgexporter_ext_log_fatal() TO pg_monitor;
 GRANT EXECUTE ON FUNCTION pgexporter_ext_log_panic() TO pg_monitor;
-
--- Renamed functions
-
-DROP FUNCTION IF EXISTS pgexporter_ext_information CASCADE;
-CREATE FUNCTION pgexporter_ext_information() RETURNS text
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_information FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_information TO pg_monitor;
-
-DROP FUNCTION IF EXISTS  pgexporter_ext_version CASCADE;
-CREATE FUNCTION pgexporter_ext_version() RETURNS text
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_version FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_version TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_is_supported CASCADE;
-CREATE FUNCTION pgexporter_ext_is_supported(IN fname text) RETURNS bool
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_is_supported FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_is_supported TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_get_functions CASCADE;
-CREATE FUNCTION pgexporter_ext_get_functions(OUT fname text, OUT has_input bool, OUT description text, OUT ftype text)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_get_functions FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_get_functions TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_os_info CASCADE;
-CREATE FUNCTION pgexporter_ext_os_info(OUT name text,
-                                       OUT version text,
-                                       OUT architecture text,
-                                       OUT host_name text,
-                                       OUT domain_name text,
-                                       OUT process_count int,
-                                       OUT uptime_seconds int
-)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_os_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_os_info TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_cpu_info CASCADE;
-CREATE FUNCTION pgexporter_ext_cpu_info(OUT vendor text,
-                                        OUT model_name text,
-                                        OUT number_of_cores int,
-                                        OUT clock_speed_hz int8,
-                                        OUT l1dcache_size int,
-                                        OUT l1icache_size int,
-                                        OUT l2cache_size int,
-                                        OUT l3cache_size int
-)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_cpu_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_cpu_info TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_memory_info CASCADE;
-CREATE FUNCTION pgexporter_ext_memory_info(OUT total_memory int8,
-                                           OUT used_memory int8,
-                                           OUT free_memory int8,
-                                           OUT swap_total int8,
-                                           OUT swap_used int8,
-                                           OUT swap_free int8,
-                                           OUT cache_total int8
-)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_memory_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_memory_info TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_load_avg CASCADE;
-CREATE FUNCTION pgexporter_ext_load_avg(OUT load_avg_one_minute float4,
-                                        OUT load_avg_five_minutes float4,
-                                        OUT load_avg_ten_minutes float4
-)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_load_avg FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_load_avg TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_network_info CASCADE;
-CREATE FUNCTION pgexporter_ext_network_info(OUT interface_name text,
-                                            OUT ip_address text,
-                                            OUT tx_bytes int8,
-                                            OUT tx_packets int8,
-                                            OUT tx_errors int8,
-                                            OUT tx_dropped int8,
-                                            OUT rx_bytes int8,
-                                            OUT rx_packets int8,
-                                            OUT rx_errors int8,
-                                            OUT rx_dropped int8,
-                                            OUT link_speed_mbps int
-)
-RETURNS SETOF record
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_network_info FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_network_info TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_used_space CASCADE;
-CREATE FUNCTION pgexporter_ext_used_space(IN dir text) RETURNS bigint
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_used_space FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_used_space TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_free_space CASCADE;
-CREATE FUNCTION pgexporter_ext_free_space(IN dir text) RETURNS bigint
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_free_space FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_free_space TO pg_monitor;
-
-DROP FUNCTION IF EXISTS pgexporter_total_space CASCADE;
-CREATE FUNCTION pgexporter_ext_total_space(IN dir text) RETURNS bigint
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
-
-REVOKE ALL ON FUNCTION pgexporter_ext_total_space FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION pgexporter_ext_total_space TO pg_monitor;

--- a/src/pgexporter_ext/lib.c
+++ b/src/pgexporter_ext/lib.c
@@ -292,7 +292,7 @@ pgexporter_ext_information(PG_FUNCTION_ARGS)
 }
 
 Datum
-pgexporter_ext_version_ext(PG_FUNCTION_ARGS)
+pgexporter_ext_version(PG_FUNCTION_ARGS)
 {
    Datum version;
    char v[1024];


### PR DESCRIPTION
### Changes
- Renamed all functions to use `pgexporter_ext_` prefix
- Removed old `DROP … CASCADE` statements and duplicate function creations in SQL scripts

### Testing
Tested on `Fedora Linux 43` with `PostgreSQL 18.1`, all working fine.

Fixes #23
